### PR TITLE
fix  env next liffId

### DIFF
--- a/templates/nextjs-ts/pages/_app.tsx
+++ b/templates/nextjs-ts/pages/_app.tsx
@@ -15,7 +15,7 @@ function MyApp({ Component, pageProps }: AppProps) {
       .then((liff) => {
         console.log("LIFF init...");
         liff
-          .init({ liffId: process.env.LIFF_ID! })
+          .init({ liffId: process.env.NEXT_PUBLIC_LIFF_ID! })
           .then(() => {
             console.log("LIFF init succeeded.");
             setLiffObject(liff);

--- a/templates/nextjs/pages/_app.js
+++ b/templates/nextjs/pages/_app.js
@@ -11,7 +11,7 @@ function MyApp({ Component, pageProps }) {
     import("@line/liff").then((liff) => {
       console.log("LIFF init...");
       liff
-        .init({ liffId: process.env.LIFF_ID })
+        .init({ liffId: process.env.NEXT_PUBLIC_LIFF_ID })
         .then(() => {
           console.log("LIFF init succeeded.");
           setLiffObject(liff);


### PR DESCRIPTION
process.env.LIFF_ID in NEXT is incorrect. When I access the URL, the following error was displayed.

>LIFF init failed.
>Error: liffId is necessary for liff.init()

So fixed it.