### PR TITLE
Fix: generate `.env.local` instead of `.env` for next.js projects

### DIFF
--- a/create-liff-app.ts
+++ b/create-liff-app.ts
@@ -35,6 +35,10 @@ const envPrefix: Record<string, string> = {
   nuxtjs: '',
   'nuxtjs-ts': ''
 };
+const envFileNameVariant: Record<string, string> = {
+  nextjs: '.env.local',
+  'nextjs-ts': '.env.local',
+};
 const rename: Record<string, string> = {
   '.gitignore.default': '.gitignore'
 };
@@ -93,7 +97,8 @@ export async function createLiffApp(answers: Answers) {
 
     // create .env file
     const content = `${envPrefix[templateName]}LIFF_ID=${liffId}`;
-    fs.writeFileSync(path.join(root, '.env'), content);
+    const envFileName = envFileNameVariant[templateName] || '.env';
+    fs.writeFileSync(path.join(root, envFileName), content);
 
     // install
     const isYarn = packageManager === 'yarn';


### PR DESCRIPTION
Unlike other frameworks, projects generated by `create-next-app` use `.env.local` instead of `.env`. This can be verified by the fact that [the `.gitignore` in the next.js template](https://github.com/line/create-liff-app/blob/89952ea870886622f78198849b01bdb8dca9f9c8/templates/nextjs-ts/.gitignore.default#L27) does not include `.env`.

This PR updates the generator to generate `.env.local` instead of `.env` for next.js projects.