### PR TITLE
Feat: add flags to the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npx @line/create-liff-app my-app
 `create-liff-app` comes with the following options:
 
 - **-t, --template &lt;template&gt;** - A template to bootstrap the app with. (available templates: "vanilla", "react", "vue", "svelte", "nextjs", "nuxtjs")
-- **-l, --id, --liffid &lt;liff id&gt;** - Liff id. For more information, please visit <https://developers.line.biz/ja/docs/liff/getting-started/>
+- **-l, --liffid &lt;liff id&gt;** - Liff id. For more information, please visit <https://developers.line.biz/ja/docs/liff/getting-started/>
 - **--js, --javascript** - Initialize as a JavaScript project
 - **--ts, --typescript** - Initialize as a TypeScript project
 - **--npm, --use-npm** - Bootstrap the app using npm

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Start developing LIFF application with a simple CLI command.
 - [Getting Started](#getting-started)
   - [Create LIFF Channel](#create-liff-channel)
   - [Installation](#installation)
+  - [Options](#options)
 - [License](#license)
 
 ## About
@@ -32,11 +33,28 @@ Before you run `create-liff-app`, we recommend creating a LIFF Channel first. Se
 
 ### Installation
 
-Run npm command like: 
-```
-$ npx @line/create-liff-app
+Run npm command like:
+```bash
+npx @line/create-liff-app
 ```
 
+To create a new app in a specific folder, you can send a name as an argument.
+```bash
+npx @line/create-liff-app my-app
+```
+
+### Options
+
+`create-liff-app` comes with the following options:
+
+- **-t, --template &lt;template&gt;** - A template to bootstrap the app with. (available templates: "vanilla", "react", "vue", "svelte", "nextjs", "nuxtjs")
+- **-l, --id, --liffid &lt;liff id&gt;** - Liff id. For more information, please visit <https://developers.line.biz/ja/docs/liff/getting-started/>
+- **--js, --javascript** - Initialize as a JavaScript project
+- **--ts, --typescript** - Initialize as a TypeScript project
+- **--npm, --use-npm** - Bootstrap the app using npm
+- **--yarn, --use-yarn** - Bootstrap the app using yarn
+- **-v, --version** - output the version number
+- **-h, --help** - display help for command
 
 ## [License](https://github.com/line/create-liff-app/blob/master/LINCENSE.txt)
 

--- a/create-liff-app.ts
+++ b/create-liff-app.ts
@@ -227,7 +227,7 @@ const questions: Array<Question | ListQuestion> = [
         console.log(`\n${chalk.yellow('The project is already exists.')}`);
         return false;
       }
-
+      
       return true;
     },
   },

--- a/create-liff-app.ts
+++ b/create-liff-app.ts
@@ -25,11 +25,11 @@ const rename: Record<string, string> = {
   '.gitignore.default': '.gitignore'
 };
 
-export function init() {
+export function init(answers: Answers = {}) {
   console.log(
     `${chalk.greenBright('Welcome')} to the ${chalk.cyan('Create LIFF App')}`
   );
-  prompt(questions).then(async (answers) => await createLiffApp(answers));
+  prompt(questions, answers).then(async (answers) => await createLiffApp(answers));
 }
 
 type PackageManager = 'npm' | 'yarn'
@@ -227,7 +227,7 @@ const questions: Array<Question | ListQuestion> = [
         console.log(`\n${chalk.yellow('The project is already exists.')}`);
         return false;
       }
-      
+
       return true;
     },
   },
@@ -393,3 +393,4 @@ const templates: Record<string, TemplateOptions> = {
     },
   },
 };
+export const templateNames = Object.keys(templates);

--- a/index.ts
+++ b/index.ts
@@ -33,7 +33,7 @@ function parseFlags() {
       new Option('-t, --template <template>', 'Choose a template to bootstrap the app with').choices(templateNames)
     )
     .option(
-      '-l, --id, --liffid <liff id>',
+      '-l, --liffid <liff id>',
       'Liff id. For more information, please visit https://developers.line.biz/ja/docs/liff/getting-started/'
     )
     .option('--js, --javascript', 'Initialize as a JavaScript project')

--- a/index.ts
+++ b/index.ts
@@ -14,6 +14,53 @@
 * under the License.
 */
 
-import { init } from './create-liff-app';
+import { Command, Option } from 'commander';
+import packageJson from './package.json';
+import { init, templateNames } from './create-liff-app';
+import type { Answers } from 'inquirer';
 
-init();
+const answers = parseFlags();
+init(answers);
+
+function parseFlags() {
+  const answers: Answers = {};
+
+  new Command(packageJson.name)
+    .version(packageJson.version, '-v, --version')
+    .usage('[project name] [options]')
+    .arguments('[projectName]')
+    .addOption(
+      new Option('-t, --template <template>', 'Choose a template to bootstrap the app with').choices(templateNames)
+    )
+    .option(
+      '-l, --id, --liffid <liff id>',
+      'Liff id. For more information, please visit https://developers.line.biz/ja/docs/liff/getting-started/'
+    )
+    .option('--js, --javascript', 'Initialize as a JavaScript project')
+    .option('--ts, --typescript', 'Initialize as a TypeScript project')
+    .option('--npm, --use-npm', 'Bootstrap the app using npm')
+    .option('--yarn, --use-yarn', 'Bootstrap the app using yarn')
+    .action((projectName, options) => {
+      const { template, liffid, javascript, typescript, useNpm, useYarn } = options;
+
+      // projectName
+      if (typeof projectName === 'string') answers.projectName = projectName;
+
+      // template
+      if (typeof template === 'string') answers.template = template;
+
+      // liffId
+      if (typeof liffid === 'string') answers.liffId = liffid;
+
+      // language
+      if (javascript) answers.language = 'JavaScript';
+      if (typescript) answers.language = 'TypeScript';
+
+      // packageManager
+      if (useNpm) answers.packageManager = 'npm';
+      if (useYarn) answers.packageManager = 'yarn';
+    })
+    .parse(process.argv);
+
+  return answers;
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@line/create-liff-app",
   "version": "1.0.5",
   "description": "Start developing LIFF application with a simple CLI command.",
-  "main": "./dist/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/line/create-liff-app"
@@ -29,6 +28,7 @@
   },
   "dependencies": {
     "chalk": "^4.1.2",
+    "commander": "^9.3.0",
     "cross-spawn": "^7.0.3",
     "inquirer": "^8.1.5",
     "validate-npm-package-name": "^3.0.0"

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -49,10 +49,10 @@ async function installProject({ args = [] as string[], inputs = [] as string[] }
   };
 }
 
-beforeAll(() => {
+beforeEach(() => {
   removeProject();
 });
-afterAll(async () => {
+afterEach(async () => {
   removeProject();
 });
 
@@ -60,7 +60,7 @@ const commands = {
   vanilla: [projectName, ENTER, ENTER, ENTER, ENTER, ENTER],
 };
 const flags = {
-  vanilla: [projectName, '-t', 'vanilla', '-l', 'id', '--js', '--use-npm'],
+  vanilla: [projectName, '-t', 'vanilla', '-l', 'id', '--js', '--use-yarn'],
 };
 
 describe('create-liff-app', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1839,6 +1839,11 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^9.3.0:
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.3.0.tgz#f619114a5a2d2054e0d9ff1b31d5ccf89255e26b"
+  integrity sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"


### PR DESCRIPTION
Add flags to the CLI (https://github.com/line/create-liff-app/issues/19)

I added some flag descriptions, but I am unsure if they sound natural (I am not a native speaker).
Please double-check the descriptions in `README.md` and the CLI help message!

Changes:

- `create-liff-app` now accepts one optional argument and various flags: `@line/create-liff-app [project name] [options]`.
- After running `@line/create-liff-app -h`, will print the following help message:

```
Usage: @line/create-liff-app [project name] [options]

Options:
  -v, --version              output the version number
  -t, --template <template>  Choose a template to bootstrap the app with (choices: "vanilla", "react", "vue", "svelte", "nextjs", "nuxtjs")
  -l, --liffid <liff id>     Liff id. For more information, please visit https://developers.line.biz/ja/docs/liff/getting-started/
  --js, --javascript         Initialize as a JavaScript project
  --ts, --typescript         Initialize as a TypeScript project
  --npm, --use-npm           Bootstrap the app using npm
  --yarn, --use-yarn         Bootstrap the app using yarn
  -h, --help                 display help for command
```

NOTE:

The [answers object](https://github.com/line/create-liff-app/compare/main...BWsix:BWsix-feat-add-flag-to-cli?expand=1#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122R26) currently has no type, as I do not know how to automatically infer the values from [questions](https://github.com/line/create-liff-app/compare/main...BWsix:BWsix-feat-add-flag-to-cli?expand=1#diff-cde1a979211c4a4f73c341450c2db77a7e625a30502cad19e87e077e67d429e4R214).
Rather than explicitly create a type for it I decided to leave it like that since answers will not be referenced by anything.
But still, I'll make it full type-safe if that sounds better to you.