### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @so99ynoodles @sugarshin @cola119 @LeeChSien
+* @line/liff


### PR DESCRIPTION
Changed `CODEOWNERS` to specify teams instead of individuals.