### PR TITLE
add always-auth: true

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           node-version: 22.x
           cache: yarn
+          always-auth: true
 
       - run: yarn install
       - run: yarn build


### PR DESCRIPTION
## Description

The following error occurred with GitHub Actions.

https://github.com/line/create-liff-app/actions/runs/12759650119/job/35563772373

<img width="1327" alt=" 2025-01-14 11 09 41" src="https://github.com/user-attachments/assets/eb976192-3eb2-4bfa-96a6-b17d8d440d3f" />

To resolve this error, I added the `always-auth` option.
ref: https://github.com/actions/setup-node/issues/81
