### PR TITLE
add files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,10 @@
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE.txt"
+  ]
 }


### PR DESCRIPTION
Related https://github.com/line/create-liff-app/issues/37

## Description

The `dist` directory was not included in the files published to npm.
By explicitly specifying the files property, we can ensure the `dist` directory will be included.

<img width="796" alt=" 2025-01-16 12 45 48" src="https://github.com/user-attachments/assets/5be9c352-2c50-4c64-bb01-caa4ef1796ae" />
