### PR TITLE
Update release-drafter.yml

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,6 +3,7 @@ tag-template: 'v$RESOLVED_VERSION'
 template: |
   # What's Changed
   $CHANGES
+
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
 commitish: refs/heads/main
 


### PR DESCRIPTION


## Description

I added a blank line to fix the broken release note style.

https://github.com/line/create-liff-app/releases/tag/v1.1.1
<img width="389" alt=" 2025-01-16 13 04 25" src="https://github.com/user-attachments/assets/44e603cf-bfbe-4397-8418-7886946f79eb" />
