### PR TITLE
Add templates in files

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "files": [
     "dist",
+    "templates",
     "README.md",
     "LICENSE.txt"
   ]


### PR DESCRIPTION
Related: https://github.com/line/create-liff-app/pull/39


## Description
I forgot to include `templates` in the files property. 

If `templates` is not included in the package, `create-liff-app` will throw an error.

```
Error: ENOENT: no such file or directory, scandir '/path/to/node_modules/@line/create-liff-app/templates/vanilla'
```

## 📝 Test Instructions:

```bash
$ npm pack # in @line/create-liff-app
$ cd /path/to/temp
$ npm install /path/to/line/create-liff-app/line-create-liff-app-1.1.3.tgz
$ npx @line/create-liff-app 
```