### PR TITLE
Pin version of GitHub Actions using SHA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: 22.x
           cache: yarn

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         with:
           disable-autolabeler: true
         env:


### PR DESCRIPTION
Closes None

## Description
To mitigate supply chain attacks in GitHub Actions, I pinned the version of GitHub Actions using SHA.
https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [GitHub Issue](https://github.com/line/create-liff-app/issues).
- [x] Filled out test instructions.
